### PR TITLE
changed href="#" to href="javascript:;"

### DIFF
--- a/src/javascripts/jquery.tocify.js
+++ b/src/javascripts/jquery.tocify.js
@@ -218,7 +218,7 @@
 
             }).append($("<a/>", {
 
-                "href": "#",
+                "href": "javascript:;",
 
                 "text": self.text()
 


### PR DESCRIPTION
This changes is necessary when using the tocify plugin within a JavaScript webapp which uses the # for routing purposes (i.e. Backbone, JavaScriptMVC,...). Otherwise clicking the link changes the hash which makes the JavaScript app react and break the behavior.
