### PR TITLE
Fix colon-space hashes

### DIFF
--- a/src/javascripts/jquery.tocify.js
+++ b/src/javascripts/jquery.tocify.js
@@ -358,6 +358,11 @@
                     hashValue = hashValue.replace(/--/g, "-");
                 }
 
+                // fix colon-space instances
+                while (hashValue.indexOf(":-") > -1) {
+                    hashValue = hashValue.replace(/:-/g, "-");
+                }
+
             } else if (typeof hashGeneratorOption === "function") {
 
                 // call the function


### PR DESCRIPTION
I do understand that I can pass in my own function, but figured this might be nice to have support out of the box for cases like this:

```
https://website.com/article/1234.html#chapter-1-something-to-talk-about
```

vs.

```
https://website.com/article/1234.html#chapter-1:-something-to-talk-about
```

while still allowing other cases like:

```
https://website.com/article/1234.html#chapter-1-http://-examples
```
