### PR TITLE
only register scroll event handler if necessary (expensive in IE)

### DIFF
--- a/src/javascripts/jquery.tocify.js
+++ b/src/javascripts/jquery.tocify.js
@@ -572,64 +572,69 @@
                 }
             });
 
+            // only attach handler if needed (expensive in IE)
+            if (self.options.extendPage || self.options.highlightOnScroll || self.options.scrollHistory || self.options.showAndHideOnScroll)
+            {
             // Window scroll event handler
-            $(window).on("scroll.tocify", function() {
+                $(window).on("scroll.tocify", function() {
 
-                // Once all animations on the page are complete, this callback function will be called
-                $("html, body").promise().done(function() {
+                    // Once all animations on the page are complete, this callback function will be called
+                    $("html, body").promise().done(function() {
 
-                    // Local variables
+                        // Local variables
 
-                    // Stores how far the user has scrolled
-                    var winScrollTop = $(window).scrollTop(),
+                        // Stores how far the user has scrolled
+                        var winScrollTop = $(window).scrollTop(),
 
-                        // Stores the height of the window
-                        winHeight = $(window).height(),
+                            // Stores the height of the window
+                            winHeight = $(window).height(),
 
-                        // Stores the height of the document
-                        docHeight = $(document).height(),
+                            // Stores the height of the document
+                            docHeight = $(document).height(),
 
-                        scrollHeight = $("body")[0].scrollHeight,
+                            scrollHeight = $("body")[0].scrollHeight,
 
-                        // Instantiates a variable that will be used to hold a selected HTML element
-                        elem,
+                            // Instantiates a variable that will be used to hold a selected HTML element
+                            elem,
 
-                        lastElem,
+                            lastElem,
 
-                        lastElemOffset,
+                            lastElemOffset,
 
-                        currentElem;
+                            currentElem;
 
-                    if(self.options.extendPage) {
+                        if(self.options.extendPage) {
 
-                        // If the user has scrolled to the bottom of the page and the last toc item is not focused
-                        if((self.webkit && winScrollTop >= scrollHeight - winHeight - self.options.extendPageOffset) || (!self.webkit && winHeight + winScrollTop > docHeight - self.options.extendPageOffset)) {
+                            // If the user has scrolled to the bottom of the page and the last toc item is not focused
+                            if((self.webkit && winScrollTop >= scrollHeight - winHeight - self.options.extendPageOffset) || (!self.webkit && winHeight + winScrollTop > docHeight - self.options.extendPageOffset)) {
 
-                            if(!$(extendPageClass).length) {
+                                if(!$(extendPageClass).length) {
 
-                                lastElem = $('div[data-unique="' + $(itemClass).last().attr("data-unique") + '"]');
+                                    lastElem = $('div[data-unique="' + $(itemClass).last().attr("data-unique") + '"]');
 
-                                if(!lastElem.length) return;
+                                    if(!lastElem.length) return;
 
-                                // Gets the top offset of the page header that is linked to the last toc item
-                                lastElemOffset = lastElem.offset().top;
+                                    // Gets the top offset of the page header that is linked to the last toc item
+                                    lastElemOffset = lastElem.offset().top;
 
-                                // Appends a div to the bottom of the page and sets the height to the difference of the window scrollTop and the last element's position top offset
-                                $(self.options.context).append($("<div />", {
+                                    // Appends a div to the bottom of the page and sets the height to the difference of the window scrollTop and the last element's position top offset
+                                    $(self.options.context).append($("<div />", {
 
-                                    "class": extendPageClassName,
+                                        "class": extendPageClassName,
 
-                                    "height": Math.abs(lastElemOffset - winScrollTop) + "px",
+                                        "height": Math.abs(lastElemOffset - winScrollTop) + "px",
 
-                                    "data-unique": extendPageClassName
+                                        "data-unique": extendPageClassName
 
-                                }));
+                                    }));
 
-                                if(self.extendPageScroll) {
+                                    if(self.extendPageScroll) {
 
-                                    currentElem = self.element.find('li.active');
+                                        currentElem = self.element.find('li.active');
 
-                                    self._scrollTo($("div[data-unique=" + currentElem.attr("data-unique") + "]"));
+                                        self._scrollTo($("div[data-unique=" + currentElem.attr("data-unique") + "]"));
+
+                                    }
 
                                 }
 
@@ -637,72 +642,71 @@
 
                         }
 
-                    }
+                        // The zero timeout ensures the following code is run after the scroll events
+                        setTimeout(function() {
 
-                    // The zero timeout ensures the following code is run after the scroll events
-                    setTimeout(function() {
+                            // _Local variables_
 
-                        // _Local variables_
+                            // Stores the distance to the closest anchor
+                            var closestAnchorDistance = null,
 
-                        // Stores the distance to the closest anchor
-                        var closestAnchorDistance = null,
+                                // Stores the index of the closest anchor
+                                closestAnchorIdx = null,
 
-                            // Stores the index of the closest anchor
-                            closestAnchorIdx = null,
+                                // Keeps a reference to all anchors
+                                anchors = $(self.options.context).find("div[data-unique]"),
 
-                            // Keeps a reference to all anchors
-                            anchors = $(self.options.context).find("div[data-unique]"),
+                                anchorText;
 
-                            anchorText;
+                            // Determines the index of the closest anchor
+                            anchors.each(function(idx) {
+                                var distance = Math.abs(($(this).next().length ? $(this).next() : $(this)).offset().top - winScrollTop - self.options.highlightOffset);
+                                if (closestAnchorDistance == null || distance < closestAnchorDistance) {
+                                    closestAnchorDistance = distance;
+                                    closestAnchorIdx = idx;
+                                } else {
+                                    return false;
+                                }
+                            });
 
-                        // Determines the index of the closest anchor
-                        anchors.each(function(idx) {
-                            var distance = Math.abs(($(this).next().length ? $(this).next() : $(this)).offset().top - winScrollTop - self.options.highlightOffset);
-                            if (closestAnchorDistance == null || distance < closestAnchorDistance) {
-                                closestAnchorDistance = distance;
-                                closestAnchorIdx = idx;
-                            } else {
-                                return false;
-                            }
-                        });
+                            anchorText = $(anchors[closestAnchorIdx]).attr("data-unique");
 
-                        anchorText = $(anchors[closestAnchorIdx]).attr("data-unique");
+                            // Stores the list item HTML element that corresponds to the currently traversed anchor tag
+                            elem = $('li[data-unique="' + anchorText + '"]');
 
-                        // Stores the list item HTML element that corresponds to the currently traversed anchor tag
-                        elem = $('li[data-unique="' + anchorText + '"]');
+                            // If the `highlightOnScroll` option is true and a next element is found
+                            if(self.options.highlightOnScroll && elem.length) {
 
-                        // If the `highlightOnScroll` option is true and a next element is found
-                        if(self.options.highlightOnScroll && elem.length) {
+                                // Removes highlighting from all of the list item's
+                                self.element.find("." + self.focusClass).removeClass(self.focusClass);
 
-                            // Removes highlighting from all of the list item's
-                            self.element.find("." + self.focusClass).removeClass(self.focusClass);
-
-                            // Highlights the corresponding list item
-                            elem.addClass(self.focusClass);
-
-                        }
-
-                        if(self.options.scrollHistory) {
-
-                            if(window.location.hash !== "#" + anchorText) {
-
-                                window.location.replace("#" + anchorText);
+                                // Highlights the corresponding list item
+                                elem.addClass(self.focusClass);
 
                             }
-                        }
 
-                        // If the `showAndHideOnScroll` option is true
-                        if(self.options.showAndHideOnScroll && self.options.showAndHide) {
+                            if(self.options.scrollHistory) {
 
-                            self._triggerShow(elem, true);
+                                if(window.location.hash !== "#" + anchorText) {
 
-                        }
+                                    window.location.replace("#" + anchorText);
 
-                    }, 0);
+                                }
+                            }
+
+                            // If the `showAndHideOnScroll` option is true
+                            if(self.options.showAndHideOnScroll && self.options.showAndHide) {
+
+                                self._triggerShow(elem, true);
+
+                            }
+
+                        }, 0);
+
+                    });
 
                 });
-
-            });
+            }
 
         },
 


### PR DESCRIPTION
If the scroll event handler is always attached, even with the scroll-detection related features disabled (`extendPage: false, scrollHistory:false, showAndHideOnScroll: false, highlightOnScroll: false`), there is a notable lag in IE due to performance issues with jQuery's `scrollTop()` (http://stackoverflow.com/a/5001300). 

This code change simply wraps the registration of the event handler in a check so that it is only registered if one of the relevant options is enabled to avoid wasting resources in a handler that ends up doing no work.
