### PR TITLE
Find all subheaders between headers regardless if they are siblings or children

### DIFF
--- a/src/javascripts/jquery.tocify.js
+++ b/src/javascripts/jquery.tocify.js
@@ -239,6 +239,12 @@
 
             self.element.addClass(tocClassName);
 
+            // find all elements regardless of sibling relationship
+            var allElem = $(this.options.context).find(this.options.selectors);
+
+            // Index of top element in allElem
+            var topIndex = 0;
+
             // Loops through each top level selector
             firstElem.each(function(index) {
 
@@ -259,45 +265,26 @@
                 // Add the created unordered list element to the HTML element calling the plugin
                 self.element.append(ul);
 
-                // Finds all of the HTML tags between the header and subheader elements
-                $(this).nextUntil(this.nodeName.toLowerCase()).each(function() {
+                // find the index of current top element in allElem
+                while (allElem[topIndex] !== this) {
+                    topIndex += 1;
+                }
+                // find the index of next top element in allElem (or the end)
+                var nextIndex = topIndex + 1;
+                while (nextIndex < allElem.length && allElem[nextIndex].nodeName.toLowerCase() !== allElem[topIndex].nodeName.toLowerCase()) {
+                    nextIndex += 1;
+                }
+                // Finds all headers between the two top elements, regardless if they are sibling or children etc
+                topIndex += 1;
+                while (topIndex < nextIndex ) {
+                    var elem = allElem[topIndex];
 
-                    // If there are no nested subheader elemements
-                    if($(this).find(self.options.selectors).length === 0) {
-
-                        // Loops through all of the subheader elements
-                        $(this).filter(self.options.selectors).each(function() {
-
-                            //If the element matches the ignoreSelector then we skip it
-                            if($(this).is(ignoreSelector)) {
-                                return;
-                            }
-
-                            self._appendSubheaders.call(this, self, ul);
-
-                        });
-
+                    //If the element matches the ignoreSelector then we skip it
+                    if( !$(elem).is(ignoreSelector)) {
+                        self._appendSubheaders.call(elem, self, ul);
                     }
-
-                    // If there are nested subheader elements
-                    else {
-
-                        // Loops through all of the subheader elements
-                        $(this).find(self.options.selectors).each(function() {
-
-                            //If the element matches the ignoreSelector then we skip it
-                            if($(this).is(ignoreSelector)) {
-                                return;
-                            }
-
-                            self._appendSubheaders.call(this, self, ul);
-
-                        });
-
-                    }
-
-                });
-
+                    topIndex += 1;
+                }
             });
 
         },


### PR DESCRIPTION
I encountered a similar problem with https://github.com/gfranko/jquery.tocify.js/issues/36. More specifically, I am adding TOCs to a bunch of jupyter notebooks whose headers are inside cells and have a structure like

```
cell -> h2
cell -> h3
cell -> h3
cell -> h2
```

tocify.js could not get the `h3`s because they are not children of `h2`. I checked the source code and find that this restriction is not really necessary so I modified the code to display all headers regardless if they are siblings or children.

The patch works but perhaps not using the best algorithm, but I would first like to know if there is any real reason for the restriction and if you are interested in merging the PR.